### PR TITLE
Refresh meta files following migration to Media WG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,27 @@
-# Web Platform Incubator Community Group
+# Contributing
 
-This repository is being used for work in the W3C Web Platform Incubator Community Group, governed by the [W3C Community License
-Agreement (CLA)](http://www.w3.org/community/about/agreements/cla/). To make substantive contributions,
-you must join the CG.
+Contributions to this repository are intended to become part of
+Recommendation-track documents governed by the
+[W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy-20200915/) and
+[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software).
+To contribute, you must either participate in the relevant W3C Working Group or
+make a non-member patent licensing commitment.
 
-If you are not the sole contributor to a contribution (pull request), please identify all
-contributors in the pull request comment.
+If you are not the sole contributor to a contribution (pull request), please
+identify all contributors in the pull request's body or in subsequent comments.
 
-To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
+To add a contributor (other than yourself, that's automatic), mark them one per
+line as follows:
 
-```
-+@github_username
-```
+ ```
+ +@github_username
+ ```
 
 If you added a contributor by mistake, you can remove them in a comment with:
 
-```
--@github_username
-```
+ ```
+ -@github_username
+ ```
 
-If you are making a pull request on behalf of someone else but you had no part in designing the
-feature, you can remove yourself with the above syntax.
+If you are making a pull request on behalf of someone else but you had no part
+in designing the feature, you can remove yourself with the above syntax.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,10 +1,2 @@
-All Reports in this Repository are licensed by Contributors
-under the
+All Reports in this Repository are licensed by Contributors under the
 [W3C Software and Document License](http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).
-
-Contributions to Specifications are made under the
-[W3C CLA](https://www.w3.org/community/about/agreements/cla/).
-
-Contributions to Test Suites are made under the
-[W3C 3-clause BSD License](https://www.w3.org/Consortium/Legal/2008/03-bsd-license.html)
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
+# Audio Session API
 
-# Specification 'audio-focus'
+This is the repository for the Audio Session API, developed by the [Media Working Group](https://www.w3.org/media-wg/).
 
-This is the repository for audio-focus. You're welcome to contribute! Let's make the Web rock our socks
-off!
+See the [explainer](explainer.md).

--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
  {
-    "group":      [80485]
-,   "contacts":   ["marcoscaceres"]
-,   "repo-type":  "cg-report"
+    "group":      "media"
+,   "contacts":   ["tidoust", "jernoble", "chrisn"]
+,   "repo-type":  "rec-track"
 }


### PR DESCRIPTION
This updates the `CONTRIBUTING.md` to explain new contributing conditions following migration to the Media Working Group.

This also drops the contributing bits from the `LICENSE.md` file, and update the `w3c.json` file to target the Media Working Group and not the WICG anymore.

README now also mentions the group and links to the explainer.