### PR TITLE
Add auto-publish job to update gh-pages branch

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,36 @@
+# Workflow based on the main w3c/spec-prod action example:
+# https://github.com/w3c/spec-prod/#basic-usage
+
+name: Build, Validate, Deploy and Publish
+
+on:
+  # Worflow runs on pull requests where it makes sure that the spec can still be
+  # generated, that markup is valid and that there are no broken links, as
+  # well as on pushes to the default branch where it also deploys the generated
+  # spec to the gh-pages branch and publishes the result to /TR.
+  # The "workflow_dispatch" hook allows admins to also trigger the workflow
+  # manually from GitHub's UI.
+  pull_request: {}
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      # See doc at https://github.com/actions/checkout#checkout-v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # See doc at https://github.com/w3c/spec-prod/#spec-prod
+      # The action only deploys the generated spec to the gh-pages branch when
+      # the workflow was triggered by a push to the default branch.
+      - name: Build and validate index.html, push to gh-pages branch if needed
+        uses: w3c/spec-prod@v2
+        with:
+          GH_PAGES_BRANCH: gh-pages
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://github.com/w3c/media-wg/issues/27
+          W3C_BUILD_OVERRIDE: |
+            status: WD

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -30,7 +30,3 @@ jobs:
         uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
-          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
-          W3C_WG_DECISION_URL: https://github.com/w3c/media-wg/issues/27
-          W3C_BUILD_OVERRIDE: |
-            status: WD


### PR DESCRIPTION
This adds a GitHub Action to publish the Editor's Draft at: https://w3c.github.io/audio-session/

<strike>Note that, once the spec will have been published as First Public Working Draft under https://www.w3.org/TR/ and the right Echidna secret has been added to the repo (which can only be done after publication), the job will also take care of keeping the version under /TR in sync with the Editor's Draft.</strike>